### PR TITLE
code changes for coming Scala 2.13.0-M5 release

### DIFF
--- a/project/GenFactories.scala
+++ b/project/GenFactories.scala
@@ -32,7 +32,7 @@ import org.scalatest.MatchersHelper.orMatchersAndApply
 import org.scalatest.words.MatcherWords
 import scala.collection.GenTraversable
 import scala.util.matching.Regex
-import org.scalactic._
+import org.scalactic.{ exceptions => _, _ }
 import TripleEqualsSupport.Spread
 import TripleEqualsSupport.TripleEqualsInvocation
 import org.scalatest.FailureMessages

--- a/scalactic-macro/src/main/scala/org/scalactic/anyvals/PosDouble.scala
+++ b/scalactic-macro/src/main/scala/org/scalactic/anyvals/PosDouble.scala
@@ -363,54 +363,6 @@ final class PosDouble private (val value: Double) extends AnyVal {
   * @return the measurement of the angle x in degrees.
   */
   def toDegrees: Double = math.toDegrees(value)
-
-  // adapted from RichInt:
-  /**
-  * Create a <code>Range</code> from this <code>PosDouble</code> value
-  * until the specified <code>end</code> (exclusive) with step value 1.
-  *
-  * @param end The final bound of the range to make.
-  * @return A [[scala.collection.immutable.Range.Partial[Double, NumericRange[Double]]]] from `this` up to but
-  * not including `end`.
-  */
-  def until(end: Double): Range.Partial[Double, NumericRange[Double]] =
-    value.until(end)
-
-  /**
-  * Create a <code>Range</code> from this <code>PosDouble</code> value
-  * until the specified <code>end</code> (exclusive) with the specified <code>step</code> value.
-  *
-  * @param end The final bound of the range to make.
-  * @param end The final bound of the range to make.
-  * @param step The number to increase by for each step of the range.
-  * @return A [[scala.collection.immutable.NumericRange.Exclusive[Double]]] from `this` up to but
-  * not including `end`.
-  */
-  def until(end: Double, step: Double): NumericRange.Exclusive[Double] =
-    value.until(end, step)
-
-  /**
-  * Create an inclusive <code>Range</code> from this <code>PosDouble</code> value
-  * to the specified <code>end</code> with step value 1.
-  *
-  * @param end The final bound of the range to make.
-  * @return A [[scala.collection.immutable.Range.Partial[Double, NumericRange[Double]]]] from `'''this'''` up to
-  * and including `end`.
-  */
-  def to(end: Double): Range.Partial[Double, NumericRange[Double]] =
-    value.to(end)
-
-  /**
-  * Create an inclusive <code>Range</code> from this <code>PosDouble</code> value
-  * to the specified <code>end</code> with the specified <code>step</code> value.
-  *
-  * @param end The final bound of the range to make.
-  * @param step The number to increase by for each step of the range.
-  * @return A [[scala.collection.immutable.NumericRange.Inclusive[Double]]] from `'''this'''` up to
-  * and including `end`.
-  */
-  def to(end: Double, step: Double): NumericRange.Inclusive[Double] =
-    value.to(end, step)
 }
 
 /**

--- a/scalactic-macro/src/main/scala/org/scalactic/anyvals/PosFloat.scala
+++ b/scalactic-macro/src/main/scala/org/scalactic/anyvals/PosFloat.scala
@@ -376,53 +376,6 @@ import scala.util.Try
   */
   def toDegrees: Float = math.toDegrees(value.toDouble).toFloat
 
-  // adapted from RichInt:
-  /**
-  * Create a <code>Range</code> from this <code>PosFloat</code> value
-  * until the specified <code>end</code> (exclusive) with step value 1.
-  *
-  * @param end The final bound of the range to make.
-  * @return A [[scala.collection.immutable.Range.Partial[Float, NumericRange[Float]]]] from `this` up to but
-  * not including `end`.
-  */
-  def until(end: Float): Range.Partial[Float, NumericRange[Float]] =
-    value.until(end)
-
-  /**
-  * Create a <code>Range</code> (exclusive) from this <code>PosFloat</code> value
-  * until the specified <code>end</code> (exclusive) with the specified <code>step</code> value.
-  *
-  * @param end The final bound of the range to make.
-  * @param end The final bound of the range to make.
-  * @param step The number to increase by for each step of the range.
-  * @return A [[scala.collection.immutable.NumericRange.Exclusive[Float]]] from `this` up to but
-  * not including `end`.
-  */
-  def until(end: Float, step: Float): NumericRange.Exclusive[Float] =
-    value.until(end, step)
-
-  /**
-  * Create an inclusive <code>Range</code> from this <code>PosFloat</code> value
-  * to the specified <code>end</code> with step value 1.
-  *
-  * @param end The final bound of the range to make.
-  * @return A [[scala.collection.immutable.Range.Partial[Float], NumericRange[Float]]] from `'''this'''` up to
-  * and including `end`.
-  */
-  def to(end: Float): Range.Partial[Float, NumericRange[Float]] =
-    value.to(end)
-
-  /**
-  * Create an inclusive <code>Range</code> from this <code>PosFloat</code> value
-  * to the specified <code>end</code> with the specified <code>step</code> value.
-  *
-  * @param end The final bound of the range to make.
-  * @param step The number to increase by for each step of the range.
-  * @return A [[scala.collection.immutable.NumericRange.Inclusive[Float]]] from `'''this'''` up to
-  * and including `end`.
-  */
-  def to(end: Float, step: Float): NumericRange.Inclusive[Float] =
-    value.to(end, step)
 }
 
 /**

--- a/scalactic-macro/src/main/scala/org/scalactic/anyvals/PosZDouble.scala
+++ b/scalactic-macro/src/main/scala/org/scalactic/anyvals/PosZDouble.scala
@@ -357,53 +357,6 @@ final class PosZDouble private (val value: Double) extends AnyVal {
   */
   def toDegrees: Double = math.toDegrees(value)
 
-  // adapted from RichInt:
-  /**
-  * Create a <code>Range</code> from this <code>PosZDouble</code> value
-  * until the specified <code>end</code> (exclusive) with step value 1.
-  *
-  * @param end The final bound of the range to make.
-  * @return A [[scala.collection.immutable.Range.Partial[Double, NumericRange[Double]]]] from `this` up to but
-  * not including `end`.
-  */
-  def until(end: Double): Range.Partial[Double, NumericRange[Double]] =
-    value.until(end)
-
-  /**
-  * Create a <code>Range</code> from this <code>PosZDouble</code> value
-  * until the specified <code>end</code> (exclusive) with the specified <code>step</code> value.
-  *
-  * @param end The final bound of the range to make.
-  * @param end The final bound of the range to make.
-  * @param step The number to increase by for each step of the range.
-  * @return A [[scala.collection.immutable.NumericRange.Exclusive[Double]]] from `this` up to but
-  * not including `end`.
-  */
-  def until(end: Double, step: Double): NumericRange.Exclusive[Double] =
-    value.until(end, step)
-
-  /**
-  * Create an inclusive <code>Range</code> from this <code>PosZDouble</code> value
-  * to the specified <code>end</code> with step value 1.
-  *
-  * @param end The final bound of the range to make.
-  * @return A [[scala.collection.immutable.Range.Partial[Double, NumericRange[Double]]]] from `'''this'''` up to
-  * and including `end`.
-  */
-  def to(end: Double): Range.Partial[Double, NumericRange[Double]] =
-    value.to(end)
-
-  /**
-  * Create an inclusive <code>Range</code> from this <code>PosZDouble</code> value
-  * to the specified <code>end</code> with the specified <code>step</code> value.
-  *
-  * @param end The final bound of the range to make.
-  * @param step The number to increase by for each step of the range.
-  * @return A [[scala.collection.immutable.NumericRange.Inclusive[Double]]] from `'''this'''` up to
-  * and including `end`.
-  */
-  def to(end: Double, step: Double): NumericRange.Inclusive[Double] =
-    value.to(end, step)
 }
 
 /**

--- a/scalactic-macro/src/main/scala/org/scalactic/anyvals/PosZFloat.scala
+++ b/scalactic-macro/src/main/scala/org/scalactic/anyvals/PosZFloat.scala
@@ -356,53 +356,6 @@ final class PosZFloat private (val value: Float) extends AnyVal {
   */
   def toDegrees: PosZFloat = PosZFloat.from(math.toDegrees(value).toFloat).get
 
-  // adapted from RichInt:
-  /**
-  * Create a <code>Range</code> from this <code>PosZFloat</code> value
-  * until the specified <code>end</code> (exclusive) with step value 1.
-  *
-  * @param end The final bound of the range to make.
-  * @return A [[scala.collection.immutable.Range.Partial[Float, NumericRange[Float]]]] from `this` up to but
-  * not including `end`.
-  */
-  def until(end: Float): Range.Partial[Float, NumericRange[Float]] =
-    value.until(end)
-
-  /**
-  * Create a <code>Range</code> from this <code>PosZFloat</code> value
-  * until the specified <code>end</code> (exclusive) with the specified <code>step</code> value.
-  *
-  * @param end The final bound of the range to make.
-  * @param end The final bound of the range to make.
-  * @param step The number to increase by for each step of the range.
-  * @return A [[scala.collection.immutable.NumericRange.Exclusive[Float]]] from `this` up to but
-  * not including `end`.
-  */
-  def until(end: Float, step: Float): NumericRange.Exclusive[Float] =
-    value.until(end, step)
-
-  /**
-  * Create an inclusive <code>Range</code> from this <code>PosZFloat</code> value
-  * to the specified <code>end</code> with step value 1.
-  *
-  * @param end The final bound of the range to make.
-  * @return A [[scala.collection.immutable.Range.Partial[Float, NumericRange[Float]]]] from `'''this'''` up to
-  * and including `end`.
-  */
-  def to(end: Float): Range.Partial[Float, NumericRange[Float]] =
-    value.to(end)
-
-  /**
-  * Create an inclusive <code>Range</code> from this <code>PosZFloat</code> value
-  * to the specified <code>end</code> with the specified <code>step</code> value.
-  *
-  * @param end The final bound of the range to make.
-  * @param step The number to increase by for each step of the range.
-  * @return A [[scala.collection.immutable.NumericRange.Inclusive[Float]]] from `'''this'''` up to
-  * and including `end`.
-  */
-  def to(end: Float, step: Float): NumericRange.Inclusive[Float] =
-    value.to(end, step)
 }
 
 /**

--- a/scalactic/src/main/scala/org/scalactic/Prettifier.scala
+++ b/scalactic/src/main/scala/org/scalactic/Prettifier.scala
@@ -202,7 +202,7 @@ object Prettifier {
             case aWrappedArray: WrappedArray[_] => "Array(" + (aWrappedArray map apply).mkString(", ") + ")"
             case anArrayOps if ArrayHelper.isArrayOps(anArrayOps) => "Array(" + (ArrayHelper.asArrayOps(anArrayOps) map apply).mkString(", ") + ")"
             case aGenMap: GenMap[_, _] =>
-              aGenMap.stringPrefix + "(" +
+              aGenMap.toString.split('(').head + "(" +
               (aGenMap.toIterator.map { case (key, value) => // toIterator is needed for consistent ordering
                 apply(key) + " -> " + apply(value)
               }).mkString(", ") + ")"
@@ -224,7 +224,7 @@ object Prettifier {
               if (isSelf)
                 aGenTraversable.toString
               else
-                aGenTraversable.stringPrefix + "(" + aGenTraversable.toIterator.map(apply(_)).mkString(", ") + ")" // toIterator is needed for consistent ordering
+                aGenTraversable.toString.split('(').head + "(" + aGenTraversable.toIterator.map(apply(_)).mkString(", ") + ")" // toIterator is needed for consistent ordering
             // SKIP-SCALATESTJS-START
             case javaCol: java.util.Collection[_] =>
               // By default java collection follows http://download.java.net/jdk7/archive/b123/docs/api/java/util/AbstractCollection.html#toString()

--- a/scalatest/src/main/scala/org/scalatest/Assertions.scala
+++ b/scalatest/src/main/scala/org/scalatest/Assertions.scala
@@ -15,7 +15,7 @@
  */
 package org.scalatest
 
-import org.scalactic._
+import org.scalactic.{ exceptions => _, Resources => _, FailureMessages => _, _ }
 import Requirements._
 import ArrayHelper.deep
 import scala.reflect.ClassTag

--- a/scalatest/src/main/scala/org/scalatest/AsyncEngine.scala
+++ b/scalatest/src/main/scala/org/scalatest/AsyncEngine.scala
@@ -16,7 +16,7 @@
 package org.scalatest
 
 import org.scalactic.Requirements._
-import org.scalactic._
+import org.scalactic.{ exceptions => _, Resources => _, _ }
 import org.scalatest.Suite._
 import java.util.ConcurrentModificationException
 import java.util.concurrent.atomic.AtomicReference

--- a/scalatest/src/main/scala/org/scalatest/AsyncFeatureSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/AsyncFeatureSpecLike.scala
@@ -15,7 +15,7 @@
  */
 package org.scalatest
 
-import org.scalactic._
+import org.scalactic.{ exceptions => _, FailureMessages => _, UnquotedString => _, Resources => _, _ }
 import scala.concurrent.Future
 import Suite.anExceptionThatShouldCauseAnAbort
 import Suite.autoTagClassAnnotations

--- a/scalatest/src/main/scala/org/scalatest/AsyncFlatSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/AsyncFlatSpecLike.scala
@@ -15,7 +15,7 @@
  */
 package org.scalatest
 
-import org.scalactic._
+import org.scalactic.{ exceptions => _, Resources => _, _ }
 import scala.concurrent.Future
 import Suite.anExceptionThatShouldCauseAnAbort
 import Suite.autoTagClassAnnotations

--- a/scalatest/src/main/scala/org/scalatest/AsyncFreeSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/AsyncFreeSpecLike.scala
@@ -15,7 +15,7 @@
  */
 package org.scalatest
 
-import org.scalactic._
+import org.scalactic.{ exceptions => _, FailureMessages => _, UnquotedString => _, Resources => _, _ }
 import scala.concurrent.Future
 import Suite.anExceptionThatShouldCauseAnAbort
 import Suite.autoTagClassAnnotations

--- a/scalatest/src/main/scala/org/scalatest/AsyncFunSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/AsyncFunSpecLike.scala
@@ -15,7 +15,7 @@
  */
 package org.scalatest
 
-import org.scalactic._
+import org.scalactic.{ exceptions => _, FailureMessages => _, UnquotedString => _, Resources => _, _ }
 import scala.concurrent.Future
 import Suite.autoTagClassAnnotations
 import words.BehaveWord

--- a/scalatest/src/main/scala/org/scalatest/AsyncFunSuiteLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/AsyncFunSuiteLike.scala
@@ -15,7 +15,7 @@
  */
 package org.scalatest
 
-import org.scalactic._
+import org.scalactic.{ Resources => _, _ }
 import scala.concurrent.Future
 import Suite.autoTagClassAnnotations
 

--- a/scalatest/src/main/scala/org/scalatest/AsyncWordSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/AsyncWordSpecLike.scala
@@ -15,7 +15,7 @@
  */
 package org.scalatest
 
-import org.scalactic._
+import org.scalactic.{ exceptions => _, FailureMessages => _, UnquotedString => _, Resources => _, _ }
 import scala.concurrent.Future
 import Suite.anExceptionThatShouldCauseAnAbort
 import Suite.autoTagClassAnnotations

--- a/scalatest/src/main/scala/org/scalatest/CompileMacro.scala
+++ b/scalatest/src/main/scala/org/scalatest/CompileMacro.scala
@@ -15,7 +15,7 @@
  */
 package org.scalatest
 
-import org.scalactic._
+import org.scalactic.{ exceptions => _, _ }
 import org.scalatest.words.{TypeCheckWord, CompileWord}
 import scala.reflect.macros.{ Context, TypecheckException, ParseException }
 import org.scalatest.exceptions.StackDepthException

--- a/scalatest/src/main/scala/org/scalatest/ConfigMap.scala
+++ b/scalatest/src/main/scala/org/scalatest/ConfigMap.scala
@@ -107,7 +107,10 @@ class ConfigMap(underlying: scala.collection.Map[String, Any]) extends scala.col
 
   override def +[A >: Any](kv: (String, A)): ConfigMap = new ConfigMap(underlying + kv)
 
-  def -(key: String): ConfigMap = new ConfigMap(underlying.filter(_._1 != key))
+  def -(key: String): ConfigMap =
+    new ConfigMap(underlying.filter(_._1 != key))
+  def -(key1: String, key2: String, keys: String*): ConfigMap =
+    new ConfigMap(underlying.filter{case (k, _) => k != key1 && k != key2 && !keys.contains(k)})
 
   override def empty: ConfigMap = new ConfigMap(Map.empty[String, Any])
 

--- a/scalatest/src/main/scala/org/scalatest/Engine.scala
+++ b/scalatest/src/main/scala/org/scalatest/Engine.scala
@@ -15,7 +15,7 @@
  */
 package org.scalatest
 
-import org.scalactic._
+import org.scalactic.{ exceptions => _, _ }
 import Requirements._
 import org.scalatest.Suite._
 import java.util.ConcurrentModificationException

--- a/scalatest/src/main/scala/org/scalatest/Fact.scala
+++ b/scalatest/src/main/scala/org/scalatest/Fact.scala
@@ -15,7 +15,7 @@
  */
 package org.scalatest
 
-import org.scalactic._
+import org.scalactic.{ UnquotedString => _, _ }
 import org.scalatest.exceptions.StackDepthException
 import org.scalatest.exceptions.TestFailedException
 import org.scalatest.exceptions.TestCanceledException

--- a/scalatest/src/main/scala/org/scalatest/FeatureSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/FeatureSpecLike.scala
@@ -15,7 +15,7 @@
  */
 package org.scalatest
 
-import org.scalactic._
+import org.scalactic.{ exceptions => _, FailureMessages => _, UnquotedString => _, _ }
 import Suite.anExceptionThatShouldCauseAnAbort
 import Suite.autoTagClassAnnotations
 import java.util.ConcurrentModificationException

--- a/scalatest/src/main/scala/org/scalatest/FreeSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/FreeSpecLike.scala
@@ -15,7 +15,7 @@
  */
 package org.scalatest
 
-import org.scalactic._
+import org.scalactic.{ exceptions => _, FailureMessages => _, UnquotedString => _, _ }
 import Suite.anExceptionThatShouldCauseAnAbort
 import Suite.autoTagClassAnnotations
 import java.util.ConcurrentModificationException

--- a/scalatest/src/main/scala/org/scalatest/FunSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/FunSpecLike.scala
@@ -15,7 +15,7 @@
  */
 package org.scalatest
 
-import org.scalactic._
+import org.scalactic.{ exceptions => _, FailureMessages => _, UnquotedString => _, _ }
 import Suite.autoTagClassAnnotations
 import words.BehaveWord
 

--- a/scalatest/src/main/scala/org/scalatest/InsertionOrderSet.scala
+++ b/scalatest/src/main/scala/org/scalatest/InsertionOrderSet.scala
@@ -22,7 +22,8 @@ private[scalatest] class InsertionOrderSet[A](elements: scala.collection.Seq[A])
   def contains(key: A): Boolean = list.contains(key)
   def iterator: Iterator[A] = list.iterator
   override def +(elem: A) = InsertionOrderSet[A](list :+ elem)
-  def -(elem: A) = InsertionOrderSet[A](list.filter(_ != elem))
+  override def -(elem: A) =
+    InsertionOrderSet[A](list.filter(_ != elem))
   def diff(that: scala.collection.Set[A]): InsertionOrderSet[A] = InsertionOrderSet(elements.diff(that.toSeq))
 }
 

--- a/scalatest/src/main/scala/org/scalatest/Inspectors.scala
+++ b/scalatest/src/main/scala/org/scalatest/Inspectors.scala
@@ -23,7 +23,7 @@ import FailureMessages.decorateToStringValue
 import enablers.Collecting
 import scala.language.higherKinds
 import enablers.InspectorAsserting
-import org.scalactic._
+import org.scalactic.{ exceptions => _, _ }
 
 /**
  * Provides nestable <em>inspector methods</em> (or just <em>inspectors</em>) that enable assertions to be made about collections.

--- a/scalatest/src/main/scala/org/scalatest/LoneElement.scala
+++ b/scalatest/src/main/scala/org/scalatest/LoneElement.scala
@@ -15,7 +15,7 @@
  */
 package org.scalatest
 
-import org.scalactic._
+import org.scalactic.{ exceptions => _, FailureMessages => _, _ }
 import enablers.Collecting
 import exceptions.StackDepthException
 

--- a/scalatest/src/main/scala/org/scalatest/Matchers.scala
+++ b/scalatest/src/main/scala/org/scalatest/Matchers.scala
@@ -15,7 +15,7 @@
  */
 package org.scalatest
 
-import org.scalactic._
+import org.scalactic.{ exceptions => _, FailureMessages => _, UnquotedString => _, Resources => _, _ }
 import org.scalatest.enablers._
 import org.scalatest.matchers._
 import org.scalatest.words._

--- a/scalatest/src/main/scala/org/scalatest/MatchersHelper.scala
+++ b/scalatest/src/main/scala/org/scalatest/MatchersHelper.scala
@@ -24,7 +24,7 @@ import scala.util.matching.Regex
 import java.lang.reflect.Field
 import org.scalatest.exceptions.TestFailedException
 import org.scalatest.exceptions.StackDepthException
-import org.scalactic._
+import org.scalactic.{ exceptions => _, FailureMessages => _, UnquotedString => _, _ }
 
 // TODO: drop generic support for be as an equality comparison, in favor of specific ones.
 // TODO: mention on JUnit and TestNG docs that you can now mix in ShouldMatchers or MustMatchers

--- a/scalatest/src/main/scala/org/scalatest/Outcome.scala
+++ b/scalatest/src/main/scala/org/scalatest/Outcome.scala
@@ -15,9 +15,9 @@
  */
 package org.scalatest
 
-import org.scalactic._
+import org.scalactic.{ exceptions => _, _ }
 import Requirements._
-import org.scalatest.exceptions.StackDepthException
+import exceptions.StackDepthException
 
 /**
  * Superclass for the possible outcomes of running a test.

--- a/scalatest/src/main/scala/org/scalatest/Suite.scala
+++ b/scalatest/src/main/scala/org/scalatest/Suite.scala
@@ -15,7 +15,7 @@
  */
 package org.scalatest
 
-import org.scalactic._
+import org.scalactic.{ exceptions => _, Resources => _, _ }
 import org.scalatest.events._
 import Requirements._
 import exceptions._

--- a/scalatest/src/main/scala/org/scalatest/WordSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/WordSpecLike.scala
@@ -15,7 +15,7 @@
  */
 package org.scalatest
 
-import org.scalactic._
+import org.scalactic.{ UnquotedString => _, FailureMessages => _, _ }
 import org.scalatest.exceptions._
 import Suite.anExceptionThatShouldCauseAnAbort
 import Suite.autoTagClassAnnotations

--- a/scalatest/src/main/scala/org/scalatest/fixture/AsyncFeatureSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/AsyncFeatureSpecLike.scala
@@ -15,7 +15,7 @@
  */
 package org.scalatest.fixture
 
-import org.scalatest._
+import org.scalatest.{ AsyncTestSuite => _, _ }
 import org.scalatest.exceptions._
 import org.scalactic.{source, Prettifier}
 import scala.concurrent.Future

--- a/scalatest/src/main/scala/org/scalatest/fixture/AsyncFlatSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/AsyncFlatSpecLike.scala
@@ -15,7 +15,7 @@
  */
 package org.scalatest.fixture
 
-import org.scalatest._
+import org.scalatest.{ AsyncTestSuite => _, _ }
 import org.scalactic.source
 import scala.concurrent.Future
 import java.util.ConcurrentModificationException

--- a/scalatest/src/main/scala/org/scalatest/fixture/AsyncFreeSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/AsyncFreeSpecLike.scala
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalatest.fixture
+package org.scalatest
+package fixture
 
-import org.scalatest._
 import org.scalatest.exceptions._
 import org.scalactic.{source, Prettifier}
 import scala.concurrent.Future

--- a/scalatest/src/main/scala/org/scalatest/fixture/AsyncFunSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/AsyncFunSpecLike.scala
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalatest.fixture
+package org.scalatest
+package fixture
 
-import org.scalatest._
 import org.scalatest.exceptions._
 import org.scalactic.{source, Prettifier}
 import scala.concurrent.Future

--- a/scalatest/src/main/scala/org/scalatest/fixture/AsyncFunSuiteLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/AsyncFunSuiteLike.scala
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalatest.fixture
+package org.scalatest
+package fixture
 
-import org.scalatest._
 import org.scalactic.source
 import scala.concurrent.Future
 import org.scalatest.Suite.autoTagClassAnnotations

--- a/scalatest/src/main/scala/org/scalatest/fixture/AsyncWordSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/AsyncWordSpecLike.scala
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalatest.fixture
+package org.scalatest
+package fixture
 
-import org.scalatest._
 import org.scalatest.exceptions._
 import org.scalactic.{source, Prettifier}
 import scala.concurrent.Future

--- a/scalatest/src/main/scala/org/scalatest/fixture/FeatureSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/FeatureSpecLike.scala
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalatest.fixture
+package org.scalatest
+package fixture
 
-import org.scalatest._
 import org.scalatest.exceptions._
 import org.scalactic.{source, Prettifier}
 import java.util.ConcurrentModificationException

--- a/scalatest/src/main/scala/org/scalatest/fixture/FlatSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/FlatSpecLike.scala
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalatest.fixture
+package org.scalatest
+package fixture
 
-import org.scalatest._
 import org.scalactic.source
 import java.util.ConcurrentModificationException
 import java.util.concurrent.atomic.AtomicReference

--- a/scalatest/src/main/scala/org/scalatest/fixture/FreeSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/FreeSpecLike.scala
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalatest.fixture
+package org.scalatest
+package fixture
 
-import org.scalatest._
 import org.scalatest.exceptions._
 import org.scalactic.{source, Prettifier}
 import java.util.ConcurrentModificationException

--- a/scalatest/src/main/scala/org/scalatest/fixture/FunSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/FunSpecLike.scala
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalatest.fixture
+package org.scalatest
+package fixture
 
-import org.scalatest._
 import org.scalatest.exceptions._
 import org.scalactic.{source, Prettifier}
 import java.util.ConcurrentModificationException

--- a/scalatest/src/main/scala/org/scalatest/fixture/FunSuiteLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/FunSuiteLike.scala
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalatest.fixture
+package org.scalatest
+package fixture
 
-import org.scalatest._
 import org.scalactic.source
 import org.scalatest.Suite.autoTagClassAnnotations
 

--- a/scalatest/src/main/scala/org/scalatest/fixture/PropSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/PropSpecLike.scala
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalatest.fixture
+package org.scalatest
+package fixture
 
-import org.scalatest._
 import org.scalactic.source
 import org.scalatest.Suite.autoTagClassAnnotations
 

--- a/scalatest/src/main/scala/org/scalatest/fixture/SpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/SpecLike.scala
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalatest.fixture
+package org.scalatest
+package fixture
 
-import org.scalatest._
 import org.scalatest.exceptions._
 import Spec._
 import Suite._

--- a/scalatest/src/main/scala/org/scalatest/fixture/WordSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/fixture/WordSpecLike.scala
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalatest.fixture
+package org.scalatest
+package fixture
 
-import org.scalatest._
 import org.scalatest.exceptions._
 import org.scalactic.{source, Prettifier}
 import java.util.ConcurrentModificationException

--- a/scalatest/src/main/scala/org/scalatest/tools/ScalaTestFramework.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/ScalaTestFramework.scala
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalatest.tools
+package org.scalatest
+package tools
 
-import org.scalatest._
 import ArgsParser._
 import SuiteDiscoveryHelper._
 import java.util.concurrent.atomic.AtomicBoolean
@@ -208,7 +208,7 @@ class ScalaTestFramework extends SbtFramework {
 
           val module = runtimeMirror.staticModule("org.scalatest.tools.Runner$")
           val obj = runtimeMirror.reflectModule(module)
-          val runnerInstance = obj.instance.asInstanceOf[Runner.type]
+          val runnerInstance = obj.instance.asInstanceOf[org.scalatest.tools.Runner.type]
 
           runnerInstance.spanScaleFactor = parseDoubleArgument(spanScaleFactors, "-F", 1.0)
           

--- a/scalatest/src/main/scala/org/scalatest/words/JavaMapWrapper.scala
+++ b/scalatest/src/main/scala/org/scalatest/words/JavaMapWrapper.scala
@@ -59,6 +59,13 @@ private[scalatest] class JavaMapWrapper[K, V](val underlying: java.util.Map[K, V
     newJavaMap.remove(key)
     new JavaMapWrapper[K, V](underlying)
   }
+  def - (key1: K, key2: K, keys: K*): scala.collection.Map[K, V] = {
+    val newJavaMap = new java.util.LinkedHashMap[K, V](underlying)
+    newJavaMap.remove(key1)
+    newJavaMap.remove(key2)
+    keys.foreach(newJavaMap.remove)
+    new JavaMapWrapper[K, V](underlying)
+  }
   override def empty = new JavaMapWrapper[K, V](new java.util.LinkedHashMap[K, V]())
   override def toString: String = if (underlying == null) "null" else underlying.toString
 }


### PR DESCRIPTION
in order to make ScalaTest green in the Scala 2.13 community build,
I had to make some imports changes as a result of
https://github.com/scala/scala/pull/6589
as well as a few other misc post-M4 changes

the particular 2.13 nightly I was working with here was
2.13.0-pre-1e904d7

this PR is not intended to be merged as-is, for multiple
reasons:

* I didn't check if these changes cross-build on other Scala versions
* these changes may be stylistically poor.  I was just poking at stuff
  until it compiled
* I only did the `scalatest` project, similar changes may be needed
  elsewhere in the full codebase

but I wanted to send the PR anyway as a heads up and to avoid any
duplicated effort.

hello @cheeseng