### PR TITLE
Renamed `EnableReflectiveInstantiation` to correct package

### DIFF
--- a/jvm/core/src/main/scala/org/scalatest/Suites.scala
+++ b/jvm/core/src/main/scala/org/scalatest/Suites.scala
@@ -53,7 +53,7 @@ import org.scalactic.exceptions.NullArgumentException
  * @author Bill Venners
  */
 //SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
-//SCALATESTNATIVE-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
+//SCALATESTNATIVE-ONLY @scala.scalanative.reflect.annotation.EnableReflectiveInstantiation
 class Suites(suitesToNest: Suite*) extends Suite { thisSuite =>
 
   requireNonNull(suitesToNest)

--- a/jvm/featurespec/src/main/scala/org/scalatest/featurespec/AnyFeatureSpecLike.scala
+++ b/jvm/featurespec/src/main/scala/org/scalatest/featurespec/AnyFeatureSpecLike.scala
@@ -43,7 +43,7 @@ import org.scalatest.exceptions._
  */
 @Finders(Array("org.scalatest.finders.FeatureSpecFinder"))
 //SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
-//SCALATESTNATIVE-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
+//SCALATESTNATIVE-ONLY @scala.scalanative.reflect.annotation.EnableReflectiveInstantiation
 trait AnyFeatureSpecLike extends TestSuite with TestRegistration with Informing with Notifying with Alerting with Documenting { thisSuite =>
 
   private final val engine = new Engine(Resources.concurrentFeatureSpecMod, "FeatureSpec")

--- a/jvm/featurespec/src/main/scala/org/scalatest/featurespec/AsyncFeatureSpecLike.scala
+++ b/jvm/featurespec/src/main/scala/org/scalatest/featurespec/AsyncFeatureSpecLike.scala
@@ -49,7 +49,7 @@ import scala.util.Try
  */
 
 //SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
-//SCALATESTNATIVE-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
+//SCALATESTNATIVE-ONLY @scala.scalanative.reflect.annotation.EnableReflectiveInstantiation
 @Finders(Array("org.scalatest.finders.FeatureSpecFinder"))
 trait AsyncFeatureSpecLike extends AsyncTestSuite with AsyncTestRegistration with Informing with Notifying with Alerting with Documenting { thisSuite =>
 

--- a/jvm/featurespec/src/main/scala/org/scalatest/featurespec/FixtureAnyFeatureSpecLike.scala
+++ b/jvm/featurespec/src/main/scala/org/scalatest/featurespec/FixtureAnyFeatureSpecLike.scala
@@ -42,7 +42,7 @@ import org.scalatest.Suite.autoTagClassAnnotations
  * @author Bill Venners
  */
 //SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
-//SCALATESTNATIVE-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
+//SCALATESTNATIVE-ONLY @scala.scalanative.reflect.annotation.EnableReflectiveInstantiation
 @Finders(Array("org.scalatest.finders.FeatureSpecFinder"))
 trait FixtureAnyFeatureSpecLike extends org.scalatest.FixtureTestSuite with org.scalatest.FixtureTestRegistration with Informing with Notifying with Alerting with Documenting { thisSuite =>
 

--- a/jvm/featurespec/src/main/scala/org/scalatest/featurespec/FixtureAsyncFeatureSpecLike.scala
+++ b/jvm/featurespec/src/main/scala/org/scalatest/featurespec/FixtureAsyncFeatureSpecLike.scala
@@ -48,7 +48,7 @@ import scala.util.Try
  * @author Bill Venners
  */
 //SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
-//SCALATESTNATIVE-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
+//SCALATESTNATIVE-ONLY @scala.scalanative.reflect.annotation.EnableReflectiveInstantiation
 @Finders(Array("org.scalatest.finders.FeatureSpecFinder"))
 trait FixtureAsyncFeatureSpecLike extends org.scalatest.FixtureAsyncTestSuite with org.scalatest.FixtureAsyncTestRegistration with Informing with Notifying with Alerting with Documenting { thisSuite =>
 

--- a/jvm/flatspec/src/main/scala/org/scalatest/flatspec/AnyFlatSpecLike.scala
+++ b/jvm/flatspec/src/main/scala/org/scalatest/flatspec/AnyFlatSpecLike.scala
@@ -47,7 +47,7 @@ import verbs.{ResultOfTaggedAsInvocation, ResultOfStringPassedToVerb, BehaveWord
  */
 @Finders(Array("org.scalatest.finders.FlatSpecFinder"))
 //SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
-//SCALATESTNATIVE-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
+//SCALATESTNATIVE-ONLY @scala.scalanative.reflect.annotation.EnableReflectiveInstantiation
 trait AnyFlatSpecLike extends TestSuite with TestRegistration with ShouldVerb with MustVerb with CanVerb with Informing with Notifying with Alerting with Documenting { thisSuite =>
 
   private final val engine = new Engine(Resources.concurrentSpecMod, "Spec")

--- a/jvm/flatspec/src/main/scala/org/scalatest/flatspec/AsyncFlatSpecLike.scala
+++ b/jvm/flatspec/src/main/scala/org/scalatest/flatspec/AsyncFlatSpecLike.scala
@@ -45,7 +45,7 @@ import scala.util.Try
  * @author Bill Venners
  */
 //SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
-//SCALATESTNATIVE-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
+//SCALATESTNATIVE-ONLY @scala.scalanative.reflect.annotation.EnableReflectiveInstantiation
 @Finders(Array("org.scalatest.finders.FlatSpecFinder"))
 trait AsyncFlatSpecLike extends AsyncTestSuite with AsyncTestRegistration with ShouldVerb with MustVerb with CanVerb with Informing with Notifying with Alerting with Documenting { thisSuite =>
 

--- a/jvm/flatspec/src/main/scala/org/scalatest/flatspec/FixtureAnyFlatSpecLike.scala
+++ b/jvm/flatspec/src/main/scala/org/scalatest/flatspec/FixtureAnyFlatSpecLike.scala
@@ -43,7 +43,7 @@ import verbs.{ResultOfTaggedAsInvocation, ResultOfStringPassedToVerb, BehaveWord
  * @author Bill Venners
  */
 //SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
-//SCALATESTNATIVE-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
+//SCALATESTNATIVE-ONLY @scala.scalanative.reflect.annotation.EnableReflectiveInstantiation
 @Finders(Array("org.scalatest.finders.FlatSpecFinder"))
 trait FixtureAnyFlatSpecLike extends org.scalatest.FixtureTestSuite with org.scalatest.FixtureTestRegistration with ShouldVerb with MustVerb with CanVerb with Informing with Notifying with Alerting with Documenting { thisSuite =>
 

--- a/jvm/flatspec/src/main/scala/org/scalatest/flatspec/FixtureAsyncFlatSpecLike.scala
+++ b/jvm/flatspec/src/main/scala/org/scalatest/flatspec/FixtureAsyncFlatSpecLike.scala
@@ -45,7 +45,7 @@ import scala.util.Try
  * @author Bill Venners
  */
 //SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
-//SCALATESTNATIVE-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
+//SCALATESTNATIVE-ONLY @scala.scalanative.reflect.annotation.EnableReflectiveInstantiation
 @Finders(Array("org.scalatest.finders.FlatSpecFinder"))
 trait FixtureAsyncFlatSpecLike extends org.scalatest.FixtureAsyncTestSuite with org.scalatest.FixtureAsyncTestRegistration with ShouldVerb with MustVerb with CanVerb with Informing with Notifying with Alerting with Documenting { thisSuite =>
 

--- a/jvm/freespec/src/main/scala/org/scalatest/freespec/AnyFreeSpecLike.scala
+++ b/jvm/freespec/src/main/scala/org/scalatest/freespec/AnyFreeSpecLike.scala
@@ -45,7 +45,7 @@ import org.scalatest.exceptions._
  */
 @Finders(Array("org.scalatest.finders.FreeSpecFinder"))
 //SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
-//SCALATESTNATIVE-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
+//SCALATESTNATIVE-ONLY @scala.scalanative.reflect.annotation.EnableReflectiveInstantiation
 trait AnyFreeSpecLike extends TestSuite with TestRegistration with Informing with Notifying with Alerting with Documenting { thisSuite =>
 
   private final val engine = new Engine(Resources.concurrentFreeSpecMod, "FreeSpec")

--- a/jvm/freespec/src/main/scala/org/scalatest/freespec/AsyncFreeSpecLike.scala
+++ b/jvm/freespec/src/main/scala/org/scalatest/freespec/AsyncFreeSpecLike.scala
@@ -46,7 +46,7 @@ import scala.util.Try
  * @author Bill Venners
  */
 //SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
-//SCALATESTNATIVE-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
+//SCALATESTNATIVE-ONLY @scala.scalanative.reflect.annotation.EnableReflectiveInstantiation
 @Finders(Array("org.scalatest.finders.FreeSpecFinder"))
 trait AsyncFreeSpecLike extends AsyncTestSuite with AsyncTestRegistration with Informing with Notifying with Alerting with Documenting { thisSuite =>
 

--- a/jvm/freespec/src/main/scala/org/scalatest/freespec/FixtureAnyFreeSpecLike.scala
+++ b/jvm/freespec/src/main/scala/org/scalatest/freespec/FixtureAnyFreeSpecLike.scala
@@ -45,7 +45,7 @@ import org.scalatest.fixture.{Transformer, NoArgTestWrapper}
  * @author Bill Venners
  */
 //SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
-//SCALATESTNATIVE-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
+//SCALATESTNATIVE-ONLY @scala.scalanative.reflect.annotation.EnableReflectiveInstantiation
 @Finders(Array("org.scalatest.finders.FreeSpecFinder"))
 trait FixtureAnyFreeSpecLike extends org.scalatest.FixtureTestSuite with org.scalatest.FixtureTestRegistration with Informing with Notifying with Alerting with Documenting { thisSuite =>
 

--- a/jvm/freespec/src/main/scala/org/scalatest/freespec/FixtureAsyncFreeSpecLike.scala
+++ b/jvm/freespec/src/main/scala/org/scalatest/freespec/FixtureAsyncFreeSpecLike.scala
@@ -46,7 +46,7 @@ import scala.util.Try
  * @author Bill Venners
  */
 //SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
-//SCALATESTNATIVE-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
+//SCALATESTNATIVE-ONLY @scala.scalanative.reflect.annotation.EnableReflectiveInstantiation
 @Finders(Array("org.scalatest.finders.FreeSpecFinder"))
 trait FixtureAsyncFreeSpecLike extends org.scalatest.FixtureAsyncTestSuite with org.scalatest.FixtureAsyncTestRegistration with Informing with Notifying with Alerting with Documenting { thisSuite =>
 

--- a/jvm/freespec/src/main/scala/org/scalatest/freespec/PathAnyFreeSpecLike.scala
+++ b/jvm/freespec/src/main/scala/org/scalatest/freespec/PathAnyFreeSpecLike.scala
@@ -46,7 +46,7 @@ import Suite.autoTagClassAnnotations
  */
 @Finders(Array("org.scalatest.finders.FreeSpecFinder"))
 //SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
-//SCALATESTNATIVE-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
+//SCALATESTNATIVE-ONLY @scala.scalanative.reflect.annotation.EnableReflectiveInstantiation
 trait PathAnyFreeSpecLike extends org.scalatest.Suite with OneInstancePerTest with Informing with Notifying with Alerting with Documenting { thisSuite =>
   
   private final val engine = PathEngine.getEngine()

--- a/jvm/funspec/src/main/scala/org/scalatest/funspec/AnyFunSpecLike.scala
+++ b/jvm/funspec/src/main/scala/org/scalatest/funspec/AnyFunSpecLike.scala
@@ -45,7 +45,7 @@ import org.scalatest.exceptions._
  */
 @Finders(Array("org.scalatest.finders.FunSpecFinder"))
 //SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
-//SCALATESTNATIVE-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
+//SCALATESTNATIVE-ONLY @scala.scalanative.reflect.annotation.EnableReflectiveInstantiation
 trait AnyFunSpecLike extends TestSuite with TestRegistration with Informing with Notifying with Alerting with Documenting { thisSuite =>
 
   private final val engine = new Engine(Resources.concurrentSpecMod, "FunSpec")

--- a/jvm/funspec/src/main/scala/org/scalatest/funspec/AsyncFunSpecLike.scala
+++ b/jvm/funspec/src/main/scala/org/scalatest/funspec/AsyncFunSpecLike.scala
@@ -46,7 +46,7 @@ import scala.util.Try
  * @author Bill Venners
  */
 //SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
-//SCALATESTNATIVE-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
+//SCALATESTNATIVE-ONLY @scala.scalanative.reflect.annotation.EnableReflectiveInstantiation
 @Finders(Array("org.scalatest.finders.FunSpecFinder"))
 trait AsyncFunSpecLike extends AsyncTestSuite with AsyncTestRegistration with Informing with Notifying with Alerting with Documenting { thisSuite =>
 

--- a/jvm/funspec/src/main/scala/org/scalatest/funspec/FixtureAnyFunSpecLike.scala
+++ b/jvm/funspec/src/main/scala/org/scalatest/funspec/FixtureAnyFunSpecLike.scala
@@ -47,7 +47,7 @@ import verbs.BehaveWord
  * @author Bill Venners
  */
 //SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
-//SCALATESTNATIVE-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
+//SCALATESTNATIVE-ONLY @scala.scalanative.reflect.annotation.EnableReflectiveInstantiation
 @Finders(Array("org.scalatest.finders.FunSpecFinder"))
 trait FixtureAnyFunSpecLike extends org.scalatest.FixtureTestSuite with org.scalatest.FixtureTestRegistration with Informing with Notifying with Alerting with Documenting { thisSuite =>
 

--- a/jvm/funspec/src/main/scala/org/scalatest/funspec/FixtureAsyncFunSpecLike.scala
+++ b/jvm/funspec/src/main/scala/org/scalatest/funspec/FixtureAsyncFunSpecLike.scala
@@ -46,7 +46,7 @@ import scala.util.Try
  * @author Bill Venners
  */
 //SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
-//SCALATESTNATIVE-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
+//SCALATESTNATIVE-ONLY @scala.scalanative.reflect.annotation.EnableReflectiveInstantiation
 @Finders(Array("org.scalatest.finders.FunSpecFinder"))
 trait FixtureAsyncFunSpecLike extends org.scalatest.FixtureAsyncTestSuite with org.scalatest.FixtureAsyncTestRegistration with Informing with Notifying with Alerting with Documenting { thisSuite =>
 

--- a/jvm/funspec/src/main/scala/org/scalatest/funspec/PathAnyFunSpecLike.scala
+++ b/jvm/funspec/src/main/scala/org/scalatest/funspec/PathAnyFunSpecLike.scala
@@ -46,7 +46,7 @@ import org.scalatest.PathEngine.isInTargetPath
  */
 @Finders(Array("org.scalatest.finders.FunSpecFinder"))
 //SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
-//SCALATESTNATIVE-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
+//SCALATESTNATIVE-ONLY @scala.scalanative.reflect.annotation.EnableReflectiveInstantiation
 trait PathAnyFunSpecLike extends org.scalatest.Suite with OneInstancePerTest with Informing with Notifying with Alerting with Documenting { thisSuite =>
   
   private final val engine = PathEngine.getEngine()

--- a/jvm/funsuite/src/main/scala/org/scalatest/funsuite/AnyFunSuite.scala
+++ b/jvm/funsuite/src/main/scala/org/scalatest/funsuite/AnyFunSuite.scala
@@ -1559,7 +1559,7 @@ import org.scalatest.{Suite, Finders}
   */
 @Finders(Array("org.scalatest.finders.FunSuiteFinder"))
 //SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
-//SCALATESTNATIVE-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
+//SCALATESTNATIVE-ONLY @scala.scalanative.reflect.annotation.EnableReflectiveInstantiation
 class AnyFunSuite extends AnyFunSuiteLike {
 
   /**

--- a/jvm/funsuite/src/main/scala/org/scalatest/funsuite/AnyFunSuiteLike.scala
+++ b/jvm/funsuite/src/main/scala/org/scalatest/funsuite/AnyFunSuiteLike.scala
@@ -43,7 +43,7 @@ import Suite.autoTagClassAnnotations
   */
 @Finders(Array("org.scalatest.finders.FunSuiteFinder"))
 //SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
-//SCALATESTNATIVE-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
+//SCALATESTNATIVE-ONLY @scala.scalanative.reflect.annotation.EnableReflectiveInstantiation
 trait AnyFunSuiteLike extends TestSuite with TestRegistration with Informing with Notifying with Alerting with Documenting { thisSuite =>
 
   private final val engine = new Engine(Resources.concurrentFunSuiteMod, "FunSuite")

--- a/jvm/funsuite/src/main/scala/org/scalatest/funsuite/AsyncFunSuite.scala
+++ b/jvm/funsuite/src/main/scala/org/scalatest/funsuite/AsyncFunSuite.scala
@@ -2187,7 +2187,7 @@ import org.scalatest.{Suite, Finders}
   * </ul>
   */
 //SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
-//SCALATESTNATIVE-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
+//SCALATESTNATIVE-ONLY @scala.scalanative.reflect.annotation.EnableReflectiveInstantiation
 @Finders(Array("org.scalatest.finders.FunSuiteFinder"))
 abstract class AsyncFunSuite extends AsyncFunSuiteLike {
 

--- a/jvm/funsuite/src/main/scala/org/scalatest/funsuite/AsyncFunSuiteLike.scala
+++ b/jvm/funsuite/src/main/scala/org/scalatest/funsuite/AsyncFunSuiteLike.scala
@@ -42,7 +42,7 @@ import scala.util.Try
   * @author Bill Venners
   */
 //SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
-//SCALATESTNATIVE-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
+//SCALATESTNATIVE-ONLY @scala.scalanative.reflect.annotation.EnableReflectiveInstantiation
 @Finders(Array("org.scalatest.finders.FunSuiteFinder"))
 trait AsyncFunSuiteLike extends AsyncTestSuite with AsyncTestRegistration with Informing with Notifying with Alerting with Documenting { thisSuite =>
 

--- a/jvm/funsuite/src/main/scala/org/scalatest/funsuite/FixtureAnyFunSuite.scala
+++ b/jvm/funsuite/src/main/scala/org/scalatest/funsuite/FixtureAnyFunSuite.scala
@@ -225,7 +225,7 @@ import org.scalatest.Suite.autoTagClassAnnotations
   * @author Bill Venners
   */
 //SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
-//SCALATESTNATIVE-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
+//SCALATESTNATIVE-ONLY @scala.scalanative.reflect.annotation.EnableReflectiveInstantiation
 @Finders(Array("org.scalatest.finders.FunSuiteFinder"))
 abstract class FixtureAnyFunSuite extends FixtureAnyFunSuiteLike {
 

--- a/jvm/funsuite/src/main/scala/org/scalatest/funsuite/FixtureAnyFunSuiteLike.scala
+++ b/jvm/funsuite/src/main/scala/org/scalatest/funsuite/FixtureAnyFunSuiteLike.scala
@@ -41,7 +41,7 @@ import org.scalatest.Suite.autoTagClassAnnotations
   * @author Bill Venners
   */
 //SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
-//SCALATESTNATIVE-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
+//SCALATESTNATIVE-ONLY @scala.scalanative.reflect.annotation.EnableReflectiveInstantiation
 @Finders(Array("org.scalatest.finders.FunSuiteFinder"))
 trait FixtureAnyFunSuiteLike extends org.scalatest.FixtureTestSuite with org.scalatest.FixtureTestRegistration with Informing with Notifying with Alerting with Documenting { thisSuite =>
 

--- a/jvm/funsuite/src/main/scala/org/scalatest/funsuite/FixtureAsyncFunSuite.scala
+++ b/jvm/funsuite/src/main/scala/org/scalatest/funsuite/FixtureAsyncFunSuite.scala
@@ -262,7 +262,7 @@ import org.scalatest.Suite.autoTagClassAnnotations
   * @author Bill Venners
   */
 //SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
-//SCALATESTNATIVE-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
+//SCALATESTNATIVE-ONLY @scala.scalanative.reflect.annotation.EnableReflectiveInstantiation
 @Finders(Array("org.scalatest.finders.FunSuiteFinder"))
 trait FixtureAsyncFunSuite extends funsuite.FixtureAsyncFunSuiteLike with Informing with Notifying with Alerting with Documenting { thisSuite =>
 

--- a/jvm/funsuite/src/main/scala/org/scalatest/funsuite/FixtureAsyncFunSuiteLike.scala
+++ b/jvm/funsuite/src/main/scala/org/scalatest/funsuite/FixtureAsyncFunSuiteLike.scala
@@ -43,7 +43,7 @@ import scala.util.Try
   * @author Bill Venners
   */
 //SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
-//SCALATESTNATIVE-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
+//SCALATESTNATIVE-ONLY @scala.scalanative.reflect.annotation.EnableReflectiveInstantiation
 @Finders(Array("org.scalatest.finders.FunSuiteFinder"))
 trait FixtureAsyncFunSuiteLike extends org.scalatest.FixtureAsyncTestSuite with org.scalatest.FixtureAsyncTestRegistration with Informing with Notifying with Alerting with Documenting { thisSuite =>
 

--- a/jvm/propspec/src/main/scala/org/scalatest/propspec/AnyPropSpecLike.scala
+++ b/jvm/propspec/src/main/scala/org/scalatest/propspec/AnyPropSpecLike.scala
@@ -41,7 +41,7 @@ import Suite.autoTagClassAnnotations
  */
 @Finders(Array("org.scalatest.finders.PropSpecFinder"))
 //SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
-//SCALATESTNATIVE-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
+//SCALATESTNATIVE-ONLY @scala.scalanative.reflect.annotation.EnableReflectiveInstantiation
 trait AnyPropSpecLike extends TestSuite with TestRegistration with Informing with Notifying with Alerting with Documenting { thisSuite =>
 
   private final val engine = new Engine(Resources.concurrentPropSpecMod, "PropSpec")

--- a/jvm/propspec/src/main/scala/org/scalatest/propspec/AsyncPropSpecLike.scala
+++ b/jvm/propspec/src/main/scala/org/scalatest/propspec/AsyncPropSpecLike.scala
@@ -41,7 +41,7 @@ import scala.util.Try
  * @author Bill Venners
  */
 //SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
-//SCALATESTNATIVE-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
+//SCALATESTNATIVE-ONLY @scala.scalanative.reflect.annotation.EnableReflectiveInstantiation
 @Finders(Array("org.scalatest.finders.PropSpecFinder"))
 trait AsyncPropSpecLike extends AsyncTestSuite with AsyncTestRegistration with Informing with Notifying with Alerting with Documenting { thisSuite =>
 

--- a/jvm/propspec/src/main/scala/org/scalatest/propspec/FixtureAnyPropSpecLike.scala
+++ b/jvm/propspec/src/main/scala/org/scalatest/propspec/FixtureAnyPropSpecLike.scala
@@ -41,7 +41,7 @@ import org.scalatest.Suite.autoTagClassAnnotations
  * @author Bill Venners
  */
 //SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
-//SCALATESTNATIVE-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
+//SCALATESTNATIVE-ONLY @scala.scalanative.reflect.annotation.EnableReflectiveInstantiation
 @Finders(Array("org.scalatest.finders.PropSpecFinder"))
 trait FixtureAnyPropSpecLike extends org.scalatest.FixtureTestSuite with org.scalatest.FixtureTestRegistration with Informing with Notifying with Alerting with Documenting { thisSuite =>
 

--- a/jvm/propspec/src/main/scala/org/scalatest/propspec/FixtureAsyncPropSpecLike.scala
+++ b/jvm/propspec/src/main/scala/org/scalatest/propspec/FixtureAsyncPropSpecLike.scala
@@ -43,7 +43,7 @@ import scala.util.Try
  * @author Bill Venners
  */
 //SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
-//SCALATESTNATIVE-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
+//SCALATESTNATIVE-ONLY @scala.scalanative.reflect.annotation.EnableReflectiveInstantiation
 @Finders(Array("org.scalatest.finders.PropSpecFinder"))
 trait FixtureAsyncPropSpecLike extends AsyncTestSuite with AsyncTestRegistration with Informing with Notifying with Alerting with Documenting { thisSuite =>
 

--- a/jvm/wordspec/src/main/scala/org/scalatest/wordspec/AnyWordSpecLike.scala
+++ b/jvm/wordspec/src/main/scala/org/scalatest/wordspec/AnyWordSpecLike.scala
@@ -40,7 +40,7 @@ import verbs.{CanVerb, ResultOfAfterWordApplication, ShouldVerb, BehaveWord,
  */
 @Finders(Array("org.scalatest.finders.WordSpecFinder"))
 //SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
-//SCALATESTNATIVE-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
+//SCALATESTNATIVE-ONLY @scala.scalanative.reflect.annotation.EnableReflectiveInstantiation
 trait AnyWordSpecLike extends TestSuite with TestRegistration with ShouldVerb with MustVerb with CanVerb with Informing with Notifying with Alerting with Documenting { thisSuite =>
 
   private final val engine = new Engine(Resources.concurrentWordSpecMod, "WordSpecLike")

--- a/jvm/wordspec/src/main/scala/org/scalatest/wordspec/AsyncWordSpecLike.scala
+++ b/jvm/wordspec/src/main/scala/org/scalatest/wordspec/AsyncWordSpecLike.scala
@@ -41,7 +41,7 @@ import scala.util.Try
  * @author Bill Venners
  */
 //SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
-//SCALATESTNATIVE-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
+//SCALATESTNATIVE-ONLY @scala.scalanative.reflect.annotation.EnableReflectiveInstantiation
 @Finders(Array("org.scalatest.finders.WordSpecFinder"))
 trait AsyncWordSpecLike extends AsyncTestSuite with AsyncTestRegistration with ShouldVerb with MustVerb with CanVerb with Informing with Notifying with Alerting with Documenting { thisSuite =>
 

--- a/jvm/wordspec/src/main/scala/org/scalatest/wordspec/FixtureAnyWordSpecLike.scala
+++ b/jvm/wordspec/src/main/scala/org/scalatest/wordspec/FixtureAnyWordSpecLike.scala
@@ -48,7 +48,7 @@ StringVerbBlockRegistration, SubjectWithAfterWordRegistration}
  * @author Bill Venners
  */
 //SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
-//SCALATESTNATIVE-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
+//SCALATESTNATIVE-ONLY @scala.scalanative.reflect.annotation.EnableReflectiveInstantiation
 @Finders(Array("org.scalatest.finders.WordSpecFinder"))
 trait FixtureAnyWordSpecLike extends org.scalatest.FixtureTestSuite with org.scalatest.FixtureTestRegistration with ShouldVerb with MustVerb with CanVerb with Informing with Notifying with Alerting with Documenting { thisSuite =>
 

--- a/jvm/wordspec/src/main/scala/org/scalatest/wordspec/FixtureAsyncWordSpecLike.scala
+++ b/jvm/wordspec/src/main/scala/org/scalatest/wordspec/FixtureAsyncWordSpecLike.scala
@@ -47,7 +47,7 @@ import scala.util.Try
  * @author Bill Venners
  */
 //SCALATESTJS-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
-//SCALATESTNATIVE-ONLY @scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
+//SCALATESTNATIVE-ONLY @scala.scalanative.reflect.annotation.EnableReflectiveInstantiation
 @Finders(Array("org.scalatest.finders.WordSpecFinder"))
 trait FixtureAsyncWordSpecLike extends org.scalatest.FixtureAsyncTestSuite with org.scalatest.FixtureAsyncTestRegistration with ShouldVerb with MustVerb with CanVerb with Informing with Notifying with Alerting with Documenting { thisSuite =>
 


### PR DESCRIPTION
A while ago I've introduced support of `EnableReflectiveInstantiation` for Scala-Native but used a package which exists in both `-M2` and `-SNAPSHOT` version of scala-native.

Since `0.4.0` was release such package should be renamed to the correct one.

Now seems the good time to do it :)